### PR TITLE
Add include for compilation on Ubuntu 17.10

### DIFF
--- a/include/Rivet/Tools/RivetSTL.hh
+++ b/include/Rivet/Tools/RivetSTL.hh
@@ -19,6 +19,7 @@
 #include <iomanip>
 #include <cmath>
 #include <limits>
+#include <functional>
 
 
 #ifndef foreach


### PR DESCRIPTION
Following up on compilation failure reported by Ruben.