### PR TITLE
backport a Rivet fix to CMS_2013_I1223519.cc

### DIFF
--- a/analyses/pluginCMS/CMS_2013_I1223519.cc
+++ b/analyses/pluginCMS/CMS_2013_I1223519.cc
@@ -123,9 +123,9 @@ namespace Rivet {
       const Jets jets37 = filter_select(alljets, Cuts::Et > 37*GeV);
       const Jets jets43 = filter_select(jets37, Cuts::Et > 43*GeV);
       const Jets jets50 = filter_select(jets43, Cuts::Et > 50*GeV);
-      const double ht37 = sum(jets37, Et, 0.0);
-      const double ht43 = sum(jets43, Et, 0.0);
-      const double ht50 = sum(jets50, Et, 0.0);
+      const double ht37 = sum(jets37, Kin::Et, 0.0);
+      const double ht43 = sum(jets43, Kin::Et, 0.0);
+      const double ht50 = sum(jets50, Kin::Et, 0.0);
 
       // Find the relevant HT bin and apply leading jet event-selection cuts
       static const vector<double> htcuts = { /* 275., 325., */ 375., 475., 575., 675., 775., 875.}; //< comment to avoid jets50 "fall-down"
@@ -153,9 +153,9 @@ namespace Rivet {
 
       // Compute DeltaHT = minimum difference of "dijet" ETs, i.e. max(|1+2-3|, |1+3-2|, |2+3-1|)
       double deltaht = -1;
-      vector<double> jetets; transform(jets, jetets, Et);
+      vector<double> jetets; transform(jets, jetets, Kin::Et);
       for (int i = 1; i < (1 << (jetets.size()-1)); ++i) { // count from 1 to 2**N-1, i.e. through all heterogeneous bitmasks with MSB(2**N)==0
-        const bitset<10> bits(i); /// @warning There'd better not be more than 10 jets...
+        const std::bitset<10> bits(i); /// @warning There'd better not be more than 10 jets...
         const double htdiff = partition_diff(bits, jetets);
         // MSG_INFO(bits.to_string() << " => " << htdiff);
         if (deltaht < 0 || htdiff < deltaht) deltaht = htdiff;
@@ -212,7 +212,7 @@ namespace Rivet {
 
     /// Sum the given values into two subsets according to the provided bitmask
     template <size_t N>
-    pair<double, double> partition_sum(const bitset<N>& mask, const vector<double>& vals) const {
+    pair<double, double> partition_sum(const std::bitset<N>& mask, const vector<double>& vals) const {
       pair<double, double> rtn(0., 0.);
       for (size_t i = 0; i < vals.size(); ++i) {
         (!mask[vals.size()-1-i] ? rtn.first : rtn.second) += vals[i];
@@ -222,7 +222,7 @@ namespace Rivet {
 
     /// Return the difference between summed subsets according to the provided bitmask
     template <size_t N>
-    double partition_diff(const bitset<N>& mask, const vector<double>& vals) const {
+    double partition_diff(const std::bitset<N>& mask, const vector<double>& vals) const {
       const pair<double, double> sums = partition_sum(mask, vals);
       const double diff = fabs(sums.first - sums.second);
       MSG_TRACE(mask.to_string() << ": " << sums.first << "/" << sums.second << " => " << diff);


### PR DESCRIPTION
The AliGenerator bundle fails to be compiled in its daily builds due to an ambiguity in one of the 335 CMS plugin analyses.
Rivet/analyses/pluginCMS/CMS_2013_I1223519.cc in 2.7.2

pluginCMS/CMS_2013_I1223519.cc:156:54: error: reference to 'Et' is ambiguous
       vector<double> jetets; transform(jets, jetets, Et);
...

The issue has in fact been spotted a few months ago by the rivet authors and fix there for later version.
("Et" -> "Kin::Et") + ("biset" -> "std::bitset")

See official Rivet commits : 
https://gitlab.com/hepcedar/rivet/commit/ced494d4016dde5dcd24567a276942fa0f64c446
https://gitlab.com/hepcedar/rivet/commit/0d5f91a4c8e66f5c6cbd7d231c73a46be9c7109a

After the merge to branch alisw/Rivet/2.7.2, a new tag should be enabled "2.7.2-alice4" and the alidist/rivet.sh updated accordingly.